### PR TITLE
Search API

### DIFF
--- a/app/interfaces.py
+++ b/app/interfaces.py
@@ -69,6 +69,8 @@ class Filter(BaseModel):
     modified_by: str | None = Field(
         default=None, description="Filter by user who last modified the record"
     )
+    # Search
+    search: str | None = Field(default=None, description="term to search for")
 
 
 class IncidentFilters(Filter):

--- a/app/models/incidents.py
+++ b/app/models/incidents.py
@@ -3,6 +3,7 @@ import hashlib
 from typing import TYPE_CHECKING, List, Literal
 from beanie import Insert, Link, Replace, before_event
 from pydantic import BaseModel, Field
+from pymongo import TEXT, IndexModel
 
 from app.audit.base import AuditedDocument
 
@@ -295,7 +296,7 @@ class EventData(BaseModel):
     )
     eventCountry: str | None = Field(
         default=None,
-        description="What country was this event? NA if The primary event did not occur in a country",
+        description="What is the alpha 3 code of the country where this event was? NA if The primary event did not occur in a country",
     )
     eventLocationCategory: (
         Literal["EEZ", "High Seas", "Inland Water", "Land"] | None
@@ -307,7 +308,7 @@ class EventData(BaseModel):
     )
     enforcementCountry: str | None = Field(
         default=None,
-        description="What country was this enforcement event? NA if The enforcement event did not occur in a country",
+        description="What is the alpha 3 code of the country where this enforcement event was? NA if The enforcement event did not occur in a country",
     )
     enforcementLocationCategory: (
         Literal["EEZ", "High Seas", "Inland Water", "Land"] | None
@@ -926,6 +927,19 @@ class IndustryOverview(AuditedDocument):
 
     class Settings:
         name = "industry_overviews"
+        indexes = [
+            # Species
+            IndexModel(
+                [
+                    ("extracted_information.species.speciesCommonName", TEXT),
+                    ("extracted_information.species.scientificName", TEXT),
+                    # Countries
+                    ("extracted_information.countries", TEXT),
+                    # Text
+                    ("extracted_information.summary", TEXT),
+                ]
+            ),
+        ]
 
     async def delete(self):
         """Override delete method to handle source removal"""
@@ -967,6 +981,25 @@ class IncidentReport(AuditedDocument):
 
     class Settings:
         name = "incidents"
+
+        indexes = [
+            IndexModel(
+                # Species
+                [
+                    ("extracted_information.speciesInvolved.speciesCommonName", TEXT),
+                    ("extracted_information.speciesInvolved.scientificName", TEXT),
+                    # Vessel
+                    ("extracted_information.vesselInformation.vesselName", TEXT),
+                    ("extracted_information.vesselInformation.vesselUniqueID", TEXT),
+                    ("extracted_information.vesselInformation.vesselFlag", TEXT),
+                    # Location
+                    ("extracted_information.eventData.eventCountry", TEXT),
+                    ("extracted_information.eventData.enforcementCountry", TEXT),
+                    # text
+                    ("extracted_information.description", TEXT),
+                ]
+            )
+        ]
 
     @before_event([Insert, Replace])
     def generate_fingerprint(self):

--- a/app/models/sources.py
+++ b/app/models/sources.py
@@ -164,7 +164,9 @@ class Source(AuditedDocument):
                 unique=True,
                 partialFilterExpression={"url": {"$type": "string"}},
             ),
-            IndexModel([("article_text", TEXT)]),
+            IndexModel(
+                [("article_text", TEXT), ("article_title", TEXT), ("publisher", TEXT)]
+            ),
         ]
 
     @model_validator(mode="after")

--- a/app/routes.py
+++ b/app/routes.py
@@ -458,6 +458,9 @@ async def list_incident_reports(filter_query: Annotated[IncidentFilters, Query()
             "$options": "i",
         }
 
+    if filter_query.search:
+        query_filters["$text"] = {"$search": filter_query.search}
+
     # Sort order
     from pymongo import ASCENDING
 
@@ -602,6 +605,9 @@ async def list_sources(filter_query: Annotated[SourceFilters, Query()]):
     if filter_query.publication_date_before:
         query_filters["publication_date"] = query_filters.get("publication_date", {})
         query_filters["publication_date"]["$lte"] = filter_query.publication_date_before
+
+    if filter_query.search:
+        query_filters["$text"] = {"$search": filter_query.search}
 
     # Sort order
     from pymongo import ASCENDING
@@ -786,6 +792,9 @@ async def list_overviews(filter_query: Annotated[OverviewFilters, Query()]):
         query_filters["created_by"] = filter_query.created_by
     if filter_query.modified_by:
         query_filters["updated_by"] = filter_query.modified_by
+
+    if filter_query.search:
+        query_filters["$text"] = {"$search": filter_query.search}
 
     # Sort order
     from pymongo import ASCENDING

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -5,6 +5,8 @@ Integration tests for API endpoints.
 import pytest
 from httpx import AsyncClient
 
+from app.models.sources import Source
+
 
 class TestIncidentsAPI:
     """Tests for /api/incidents endpoints."""
@@ -75,6 +77,182 @@ class TestIncidentsAPI:
         # All returned incidents should have status 'extracted'
         for report in data["reports"]:
             assert report["status"] == "extracted"
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_matches_vessel_name(
+        self, async_client: AsyncClient, sample_incident
+    ):
+        """Test that search returns incidents whose vessel name contains the term."""
+        # sample_incident has vesselName "Test Vessel"
+        response = await async_client.get("/api/incidents?search=Vessel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+        ids = [r.get("id") or r.get("_id") for r in data["reports"]]
+        assert str(sample_incident.id) in ids
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_matches_description(
+        self, async_client: AsyncClient, sample_incident
+    ):
+        """Test that search matches against the extracted description field."""
+        # sample_incident description: "Test vessel caught fishing illegally..."
+        response = await async_client.get("/api/incidents?search=illegally")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_no_match_returns_empty(
+        self, async_client: AsyncClient, sample_incident
+    ):
+        """Test that an unmatched search term returns no incidents."""
+        response = await async_client.get("/api/incidents?search=XYZZY_NOMATCH_12345")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] == 0
+        assert data["reports"] == []
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_excludes_non_matching(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search only returns incidents containing the search term."""
+        from app.models.incidents import (
+            IncidentReport,
+            ExtractedIncidentData,
+            VesselData,
+            EventData,
+            IncidentClassification,
+            IllegalFishingClassification,
+            Species,
+        )
+
+        matching = IncidentReport(
+            extracted_information=ExtractedIncidentData(
+                vesselInformation=VesselData(vesselName="Neptune Explorer"),
+                eventData=EventData(
+                    eventDate="2024-03-01",
+                    eventLocation="Atlantic Ocean",
+                    resolution="Vessel detained",
+                ),
+                speciesInvolved=[Species(speciesCommonName="Cod")],
+                productsInvolved=[],
+                description="Neptune Explorer seized for illegal trawling.",
+            ),
+            incident_classification=IncidentClassification(
+                iuuClassifications=[
+                    IllegalFishingClassification(
+                        IUUTypeReason="Vessel trawled without a valid permit."
+                    )
+                ]
+            ),
+            status="extracted",
+        )
+        non_matching = IncidentReport(
+            extracted_information=ExtractedIncidentData(
+                vesselInformation=VesselData(vesselName="Pacific Star"),
+                eventData=EventData(
+                    eventDate="2024-04-01",
+                    eventLocation="Pacific Ocean",
+                    resolution="Fine issued",
+                ),
+                speciesInvolved=[Species(speciesCommonName="Tuna")],
+                productsInvolved=[],
+                description="Pacific Star fined for quota violation.",
+            ),
+            incident_classification=IncidentClassification(
+                iuuClassifications=[
+                    IllegalFishingClassification(
+                        IUUTypeReason="Vessel exceeded its annual quota."
+                    )
+                ]
+            ),
+            status="extracted",
+        )
+        await matching.insert()
+        await non_matching.insert()
+
+        response = await async_client.get("/api/incidents?search=Neptune")
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [r.get("id") or r.get("_id") for r in data["reports"]]
+        assert str(matching.id) in returned_ids
+        assert str(non_matching.id) not in returned_ids
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_combined_with_status_filter(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search composes correctly with status filter."""
+        from app.models.incidents import (
+            IncidentReport,
+            ExtractedIncidentData,
+            VesselData,
+            EventData,
+            IncidentClassification,
+            IllegalFishingClassification,
+            Species,
+        )
+
+        extracted = IncidentReport(
+            extracted_information=ExtractedIncidentData(
+                vesselInformation=VesselData(vesselName="Coral Dawn"),
+                eventData=EventData(
+                    eventDate="2024-05-01",
+                    eventLocation="Indian Ocean",
+                    resolution="Under investigation",
+                ),
+                speciesInvolved=[Species(speciesCommonName="Shark")],
+                productsInvolved=[],
+                description="Coral Dawn investigated for shark finning.",
+            ),
+            incident_classification=IncidentClassification(
+                iuuClassifications=[
+                    IllegalFishingClassification(
+                        IUUTypeReason="Vessel caught prohibited species."
+                    )
+                ]
+            ),
+            status="extracted",
+        )
+        user_input = IncidentReport(
+            extracted_information=ExtractedIncidentData(
+                vesselInformation=VesselData(vesselName="Coral Reef"),
+                eventData=EventData(
+                    eventDate="2024-06-01",
+                    eventLocation="Red Sea",
+                    resolution="Charges pending",
+                ),
+                speciesInvolved=[Species(speciesCommonName="Grouper")],
+                productsInvolved=[],
+                description="Coral Reef reported for finning violations.",
+            ),
+            incident_classification=IncidentClassification(
+                iuuClassifications=[
+                    IllegalFishingClassification(
+                        IUUTypeReason="Vessel finned sharks without authorization."
+                    )
+                ]
+            ),
+            status="user_input",
+        )
+        await extracted.insert()
+        await user_input.insert()
+
+        response = await async_client.get(
+            "/api/incidents?search=Coral&status=extracted"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [r.get("id") or r.get("_id") for r in data["reports"]]
+        assert str(extracted.id) in returned_ids
+        assert str(user_input.id) not in returned_ids
 
 
 class TestSourcesAPI:
@@ -147,6 +325,116 @@ class TestSourcesAPI:
         for source in data["sources"]:
             assert source["input_category"] == "url"
 
+    @pytest.mark.asyncio
+    async def test_search_sources_matches_article_text(
+        self, async_client: AsyncClient, sample_source
+    ):
+        """Test that search returns sources whose article_text contains the term."""
+        response = await async_client.get("/api/sources?search=vessel")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+        ids = [s.get("id") or s.get("_id") for s in data["sources"]]
+        assert str(sample_source.id) in ids
+
+    @pytest.mark.asyncio
+    async def test_search_sources_matches_publisher(
+        self, async_client: AsyncClient, sample_source
+    ):
+        """Test that search matches against the publisher field."""
+        # sample_source publisher is "Test News"
+        response = await async_client.get("/api/sources?search=News")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_search_sources_no_match_returns_empty(
+        self, async_client: AsyncClient, sample_source
+    ):
+        """Test that a search term with no matches returns an empty result set."""
+        response = await async_client.get("/api/sources?search=XYZZY_NOMATCH_12345")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] == 0
+        assert data["sources"] == []
+
+    @pytest.mark.asyncio
+    async def test_search_sources_excludes_non_matching(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search only returns sources containing the search term."""
+        matching = Source(
+            article_text="The trawler Neptune was seized for unreported salmon catch.",
+            article_title="Neptune Seizure",
+            publisher="Ocean Watch",
+            source_type="news",
+            status="extracted",
+        )
+        non_matching = Source(
+            article_text="Government announces new aquaculture subsidy program.",
+            article_title="Aquaculture Policy Update",
+            publisher="Fisheries Digest",
+            source_type="government",
+            status="extracted",
+        )
+        await matching.insert()
+        await non_matching.insert()
+
+        response = await async_client.get("/api/sources?search=Neptune")
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [s.get("id") or s.get("_id") for s in data["sources"]]
+        assert str(matching.id) in returned_ids
+        assert str(non_matching.id) not in returned_ids
+
+    @pytest.mark.asyncio
+    async def test_search_combined_with_source_type_filter(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search composes correctly with other filters."""
+        news_source = Source(
+            article_text="Illegal trawling detected off the coast of Iceland.",
+            article_title="Iceland Trawling",
+            publisher="Fishing Weekly",
+            source_type="news",
+            status="extracted",
+        )
+        gov_source = Source(
+            article_text="Illegal trawling enforcement report from coast guard.",
+            article_title="Coast Guard Report",
+            publisher="Ministry of Fisheries",
+            source_type="government",
+            status="extracted",
+        )
+        await news_source.insert()
+        await gov_source.insert()
+
+        response = await async_client.get(
+            "/api/sources?search=trawling&source_type=government"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [s.get("id") or s.get("_id") for s in data["sources"]]
+        assert str(gov_source.id) in returned_ids
+        assert str(news_source.id) not in returned_ids
+
+    @pytest.mark.asyncio
+    async def test_search_absent_returns_all_sources(
+        self, async_client: AsyncClient, sample_source
+    ):
+        """Test that omitting the search param returns all sources unfiltered."""
+        response = await async_client.get("/api/sources")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+
 
 class TestOverviewsAPI:
     """Tests for /api/overviews endpoints."""
@@ -160,6 +448,121 @@ class TestOverviewsAPI:
         data = response.json()
         assert data["overviews"] == []
         assert data["pagination"]["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_search_overviews_matches_summary(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search returns overviews whose summary contains the term."""
+        from app.models.incidents import IndustryOverview, IndustryOverviewExtract
+
+        overview = IndustryOverview(
+            extracted_information=IndustryOverviewExtract(
+                species=[],
+                countries=["NOR", "ISL"],
+                companies=[],
+                incidents=[],
+                summary="Rising levels of unreported herring catch in Nordic waters.",
+            )
+        )
+        await overview.insert()
+
+        response = await async_client.get("/api/overviews?search=herring")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+        ids = [o.get("id") or o.get("_id") for o in data["overviews"]]
+        assert str(overview.id) in ids
+
+    @pytest.mark.asyncio
+    async def test_search_overviews_matches_country(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search matches against the countries array."""
+        from app.models.incidents import (
+            IndustryOverview,
+            IndustryOverviewExtract,
+            Species,
+        )
+
+        overview = IndustryOverview(
+            extracted_information=IndustryOverviewExtract(
+                species=[Species(speciesCommonName="Salmon")],
+                countries=["Kamchatka"],
+                companies=[],
+                incidents=[],
+                summary="Overview of salmon poaching incidents.",
+            )
+        )
+        await overview.insert()
+
+        response = await async_client.get("/api/overviews?search=Kamchatka")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_search_overviews_no_match_returns_empty(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that an unmatched search term returns no overviews."""
+        from app.models.incidents import IndustryOverview, IndustryOverviewExtract
+
+        overview = IndustryOverview(
+            extracted_information=IndustryOverviewExtract(
+                species=[],
+                countries=["AUS"],
+                companies=[],
+                incidents=[],
+                summary="Overview of fishing trends in Australian waters.",
+            )
+        )
+        await overview.insert()
+
+        response = await async_client.get("/api/overviews?search=XYZZY_NOMATCH_12345")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] == 0
+        assert data["overviews"] == []
+
+    @pytest.mark.asyncio
+    async def test_search_overviews_excludes_non_matching(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Test that search only returns overviews containing the search term."""
+        from app.models.incidents import IndustryOverview, IndustryOverviewExtract
+
+        matching = IndustryOverview(
+            extracted_information=IndustryOverviewExtract(
+                species=[],
+                countries=["CHL"],
+                companies=[],
+                incidents=[],
+                summary="Widespread squid poaching reported off Chilean coast.",
+            )
+        )
+        non_matching = IndustryOverview(
+            extracted_information=IndustryOverviewExtract(
+                species=[],
+                countries=["JPN"],
+                companies=[],
+                incidents=[],
+                summary="Annual industry report on Japanese aquaculture.",
+            )
+        )
+        await matching.insert()
+        await non_matching.insert()
+
+        response = await async_client.get("/api/overviews?search=squid")
+
+        assert response.status_code == 200
+        data = response.json()
+        returned_ids = [o.get("id") or o.get("_id") for o in data["overviews"]]
+        assert str(matching.id) in returned_ids
+        assert str(non_matching.id) not in returned_ids
 
 
 class TestLogsAPI:


### PR DESCRIPTION
Added Search to API.

Accessible by GET api/{document}?search{query}

Fields are for each document:
- Incidents
    - Vessel Name
    - Vessel ID
    - Vessel Flag
    - Species
    - Event Country
    - Enforcement Country
    - Description
- Sources 
   - Full Text
   - Publisher
   - Article Title
 - Overview
   - Country
   - Species