### PR TITLE
feature: hides full text from unauthenticated users

### DIFF
--- a/app/routes/sources.py
+++ b/app/routes/sources.py
@@ -10,7 +10,7 @@ from fastapi import (
 from pymongo import ASCENDING, DESCENDING
 from typing import Annotated
 
-from app.auth import get_current_user, get_current_admin_user
+from app.auth import get_current_user, get_current_admin_user, get_optional_user
 from app.interfaces import SourceFilters
 from app.models.sources import Source
 from app.models.users import User
@@ -22,9 +22,38 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/sources", tags=["sources"])
 
+TEXT_PREVIEW_MIN_CHARS = 300
+TEXT_PREVIEW_MAX_CHARS = 400
+
+
+def _truncate_text(text: str) -> str:
+    """Cut text at a word boundary between MIN and MAX chars, appending '...'."""
+    if len(text) <= TEXT_PREVIEW_MAX_CHARS:
+        return text
+    cut = text.rfind(" ", TEXT_PREVIEW_MIN_CHARS, TEXT_PREVIEW_MAX_CHARS)
+    if cut == -1:
+        cut = TEXT_PREVIEW_MAX_CHARS
+    return text[:cut] + "..."
+
+
+def _redact_source(source: Source) -> Source:
+    """Reduce full-text fields to a preview for non-admin viewers."""
+    source.article_text = _truncate_text(source.article_text)
+    if source.incident_passages:
+        for passage in source.incident_passages:
+            passage.full_context = ""
+    return source
+
+
+def _is_admin(user: User | None) -> bool:
+    return user is not None and user.role == "admin"
+
 
 @router.get("")
-async def list_sources(filter_query: Annotated[SourceFilters, Query()]):
+async def list_sources(
+    filter_query: Annotated[SourceFilters, Query()],
+    current_user: User | None = Depends(get_optional_user),
+):
     """
     Retrieves a list of sources with pagination and filtering.
     """
@@ -90,6 +119,9 @@ async def list_sources(filter_query: Annotated[SourceFilters, Query()]):
 
     total_count = await Source.find(query_filters).count()
 
+    if not _is_admin(current_user):
+        sources = [_redact_source(s) for s in sources]
+
     return {
         "sources": sources,
         "pagination": {
@@ -102,10 +134,15 @@ async def list_sources(filter_query: Annotated[SourceFilters, Query()]):
 
 
 @router.get("/{source_id}", response_model=Source)
-async def get_source(source_id: str):
+async def get_source(
+    source_id: str,
+    current_user: User | None = Depends(get_optional_user),
+):
     valid_object_id(source_id)
     source = await Source.get(source_id)
     valid_response(source, Source)
+    if not _is_admin(current_user):
+        source = _redact_source(source)
     return source
 
 

--- a/scripts/_review_lib.py
+++ b/scripts/_review_lib.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 EXCLUDED_LEAVES = {
     "eventData.eventCountry",
     "eventData.enforcementCountry",
+    "complianceInformation.partyToPMSA",
+    "complianceInformation.partyToPSMA",
 }
 
 EXCLUDED_LEAF_NAMES = {"verified", "description"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,9 +248,9 @@ async def sample_incident(test_db, sample_source: Source) -> IncidentReport:
 async def sample_user(test_db) -> User:
     """Create and return a sample User for testing."""
     user = User(
-        id="test-user-id",
         email="test@example.com",
         name="Test User",
+        hashedPassword="not-a-real-hash",
         role="user",
         is_active=True,
     )
@@ -262,9 +262,9 @@ async def sample_user(test_db) -> User:
 async def admin_user(test_db) -> User:
     """Create and return an admin User for testing."""
     user = User(
-        id="admin-user-id",
         email="admin@example.com",
         name="Admin User",
+        hashedPassword="not-a-real-hash",
         role="admin",
         is_active=True,
     )

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -5,7 +5,24 @@ Integration tests for API endpoints.
 import pytest
 from httpx import AsyncClient
 
-from app.models.sources import Source
+from app.auth import get_optional_user
+from app.main import app
+from app.models.sources import IncidentPassage, Source
+from tests.conftest import make_source
+
+# Article text long enough to trigger the non-admin preview truncation
+LONG_ARTICLE_TEXT = "Illegal fishing vessel spotted near the coast. " * 25
+
+
+@pytest.fixture
+def override_optional_user():
+    """Override get_optional_user with a fixed user; cleans up after the test."""
+
+    def _override(user):
+        app.dependency_overrides[get_optional_user] = lambda: user
+
+    yield _override
+    app.dependency_overrides.pop(get_optional_user, None)
 
 
 class TestIncidentsAPI:
@@ -434,6 +451,97 @@ class TestSourcesAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["pagination"]["total"] >= 1
+
+    async def _insert_long_source(self) -> Source:
+        """Insert a source with full text in article_text and incident_passages."""
+        source = make_source(
+            article_text=LONG_ARTICLE_TEXT,
+            incident_passages=[
+                IncidentPassage(
+                    target_passage="Vessel A was seized for illegal fishing.",
+                    full_context=LONG_ARTICLE_TEXT,
+                )
+            ],
+        )
+        await source.insert()
+        return source
+
+    @pytest.mark.asyncio
+    async def test_get_source_anonymous_gets_truncated_text(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Anonymous users only get a preview of article_text and no full_context."""
+        source = await self._insert_long_source()
+
+        response = await async_client.get(f"/api/sources/{source.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["article_text"].endswith("...")
+        assert len(data["article_text"]) <= 403
+        passage = data["incident_passages"][0]
+        assert passage["target_passage"] == "Vessel A was seized for illegal fishing."
+        assert passage["full_context"] == ""
+
+    @pytest.mark.asyncio
+    async def test_list_sources_anonymous_gets_truncated_text(
+        self, async_client: AsyncClient, test_db
+    ):
+        """Source list returns previews for anonymous users."""
+        await self._insert_long_source()
+
+        response = await async_client.get("/api/sources")
+
+        assert response.status_code == 200
+        listed = response.json()["sources"][0]
+        assert listed["article_text"].endswith("...")
+        assert len(listed["article_text"]) <= 403
+        assert listed["incident_passages"][0]["full_context"] == ""
+
+    @pytest.mark.asyncio
+    async def test_get_source_non_admin_user_gets_truncated_text(
+        self, async_client: AsyncClient, sample_user, override_optional_user
+    ):
+        """Logged-in non-admin users also only get the preview."""
+        source = await self._insert_long_source()
+        override_optional_user(sample_user)
+
+        response = await async_client.get(f"/api/sources/{source.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["article_text"].endswith("...")
+        assert len(data["article_text"]) <= 403
+
+    @pytest.mark.asyncio
+    async def test_get_source_admin_gets_full_text(
+        self, async_client: AsyncClient, admin_user, override_optional_user
+    ):
+        """Admin users receive the complete article text and full_context."""
+        source = await self._insert_long_source()
+        override_optional_user(admin_user)
+
+        response = await async_client.get(f"/api/sources/{source.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["article_text"] == LONG_ARTICLE_TEXT
+        assert data["incident_passages"][0]["full_context"] == LONG_ARTICLE_TEXT
+
+    @pytest.mark.asyncio
+    async def test_list_sources_admin_gets_full_text(
+        self, async_client: AsyncClient, admin_user, override_optional_user
+    ):
+        """Source list returns complete article text for admin users."""
+        await self._insert_long_source()
+        override_optional_user(admin_user)
+
+        response = await async_client.get("/api/sources")
+
+        assert response.status_code == 200
+        listed = response.json()["sources"][0]
+        assert listed["article_text"] == LONG_ARTICLE_TEXT
+        assert listed["incident_passages"][0]["full_context"] == LONG_ARTICLE_TEXT
 
 
 class TestOverviewsAPI:


### PR DESCRIPTION
We now do not show the full text in the source or multi ioncident candidate passages to users unless they are singed in admin accounts